### PR TITLE
DebugTool wraps OpenAI client and proxies chat.create

### DIFF
--- a/examples/openai_example.py
+++ b/examples/openai_example.py
@@ -1,32 +1,22 @@
 import os
-from prompt_doctor import PromptManager, DebugTool
+from prompt_doctor import DebugTool
 from openai import OpenAI
 
 # Set up OpenAI API key
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 OPENAI_MODEL = "gpt-4o-mini"
 
-prompt_manager = PromptManager()
-debug_tool = DebugTool(prompts_dir='prompts')
+debug_tool = DebugTool(client, prompts_dir='prompts')
 
 # Define a prompt ID and initial prompt text
 prompt_id = "my_prompt"
-initial_prompt = "This is a test prompt for {{name}}"
-
-context = {}
-
-refined_prompt = debug_tool.run(prompt_id, initial_prompt, context)
+context = {"name": "Alice", "age": 25, "location": "New York"}
 
 # Note this call may be redundant if we're using the debug tool to refine the prompt
-response = client.chat.completions.create(
+response = debug_tool.create(
     model=OPENAI_MODEL,
-    messages=[
-        {
-            "role": "system",
-            "content": "You are a friendly AI assistant. Greet the user and ask how you can help them today.",
-        },
-        {"role": "user", "content": refined_prompt},
-    ],
+    prompt_id=prompt_id,
+    context=context,
 )
 
 # Print the LLM response

--- a/prompt_doctor/debug_tool.py
+++ b/prompt_doctor/debug_tool.py
@@ -1,65 +1,103 @@
-from flask import Flask, render_template, request, jsonify
-from .prompt_manager import PromptManager
-from .llm_call import call_llm_api
+import json
+import logging
 import threading
 import webbrowser
-import json
+from pathlib import Path
+
+from flask import Flask, render_template, request, redirect
+from jinja2 import Template
+from openai import OpenAI
+from openai.types.chat.chat_completion import ChatCompletion
+from werkzeug.serving import make_server
+
+logger = logging.getLogger(__name__)
 
 
 class DebugTool:
-    def __init__(self, prompts_dir="prompts"):
-        self.app = Flask(__name__)
-        self.prompt_manager = PromptManager(prompts_dir)
-        self.current_prompt_id = None
-        self.current_initial_prompt = None
-        self.current_context = None
 
-        @self.app.route("/", methods=["GET", "POST"])
+    def __init__(self, oai_client: OpenAI, prompts_dir="prompts"):
+        self.llm_client = oai_client
+        self.prompts_dir = Path(prompts_dir)
+
+    def _call_llm(self, prompt: str, **oai_kwargs) -> ChatCompletion:
+        # TODO: extend template to support multiple messages/roles
+        return self.llm_client.chat.completions.create(
+            messages=[{"content": prompt, "role": "user"}],
+            **oai_kwargs)
+
+    def create(self, prompt_id: str, context: dict, **oai_kwargs) -> ChatCompletion:
+
+        if "messages" in oai_kwargs:
+            raise ValueError(
+                "The 'messages' parameter is not supported in the debug tool. Use 'template_name' instead.")
+
+        prompt_file_name = self.prompts_dir / (prompt_id + ".txt")
+
+        # Create prompt if it doesn't exist
+        if not prompt_file_name.exists():
+            with prompt_file_name.open("w") as f:
+                f.write("Write your prompt template here using Jinja syntax")
+
+        # Read the prompt template
+        with prompt_file_name.open("r") as f:
+            current_prompt_template = f.read()
+
+        # Render and call the LLM
+        current_rendered_prompt = Template(current_prompt_template).render(context)
+        current_llm_response = self._call_llm(current_rendered_prompt, **oai_kwargs)
+
+        server_lock = threading.Semaphore(0)
+
+        app = Flask(__name__)
+
+        @app.route("/done", methods=["GET"])
+        def done():
+            server_lock.release()
+            return "You can close this tab now."
+
+        @app.route("/", methods=["GET", "POST"])
         def debug_prompt():
+            nonlocal current_prompt_template, current_rendered_prompt, current_llm_response
+
             if request.method == "POST":
-                prompt_id = request.form["prompt_id"]
-                prompt_text = request.form["prompt_text"]
-                context = json.loads(request.form["context"])
-
-                new_version = self.prompt_manager.save_prompt(prompt_id, prompt_text)
-                rendered_prompt = self.prompt_manager.render_prompt(
-                    prompt_id, str(new_version), context
-                )
-
-                # Call the OpenAI API
-                api_response = call_llm_api(rendered_prompt)
-
-                return jsonify(
-                    {
-                        "rendered_prompt": rendered_prompt,
-                        "version": new_version,
-                        "api_response": api_response,
-                    }
-                )
+                match request.form["action"]:
+                    case "call_llm":
+                        current_prompt_template = request.form["prompt_template"]
+                        current_rendered_prompt = Template(current_prompt_template).render(context)
+                        current_llm_response = self._call_llm(current_rendered_prompt, **oai_kwargs)
+                        redirect("/")
+                    case "save_and_quit":
+                        with prompt_file_name.open("w") as f:
+                            f.write(request.form["prompt_template"])
+                        return redirect("/done")
+                    case "discard_and_quit":
+                        return redirect("/done")
+                    case _:
+                        raise ValueError("Invalid action")
 
             return render_template(
                 "debug_tool.html",
-                prompt_id=self.current_prompt_id,
-                initial_prompt=self.current_initial_prompt,
-                context=json.dumps(self.current_context, indent=2),
+                prompt_id=prompt_id,
+                prompt_template=current_prompt_template,
+                rendered_prompt=current_rendered_prompt,
+                context=json.dumps(context, indent=2),
+                llm_response=current_llm_response.model_dump_json(indent=2)
             )
 
-    def run(self, prompt_id, initial_prompt, context):
-        self.current_prompt_id = prompt_id
-        self.current_initial_prompt = initial_prompt
-        self.current_context = context
-
         # Start the Flask app in a separate thread
-        threading.Thread(target=self.app.run, daemon=True).start()
+        server = make_server("localhost", 5000, app)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        logger.info("Debug tool started at http://127.0.0.1:5000")
 
         # Open the debug tool in the default web browser
         webbrowser.open("http://127.0.0.1:5000")
 
-        # Wait for user input to continue
-        input("Press Enter to continue after finishing with the debug tool...")
+        # Wait for the server to finish
+        server_lock.acquire(blocking=True)
+        server.shutdown()
+        server_thread.join()
+        logger.info("Debug tool closed")
 
-        # Return the latest version of the prompt
-        latest_version = self.prompt_manager.list_versions(prompt_id)[0]
-        return self.prompt_manager.get_prompt(prompt_id, str(latest_version)).render(
-            context
-        )
+        # Return the latest LLM response
+        return current_llm_response

--- a/prompt_doctor/debug_tool.py
+++ b/prompt_doctor/debug_tool.py
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 class DebugTool:
 
-    def __init__(self, oai_client: OpenAI, prompts_dir="prompts"):
+    def __init__(self, oai_client: OpenAI, prompts_dir="prompts", open_browser=True):
         self.llm_client = oai_client
         self.prompts_dir = Path(prompts_dir)
+        self.open_browser = open_browser
 
     def _call_llm(self, prompt: str, **oai_kwargs) -> ChatCompletion:
         # TODO: extend template to support multiple messages/roles
@@ -91,7 +92,8 @@ class DebugTool:
         logger.info("Debug tool started at http://127.0.0.1:5000")
 
         # Open the debug tool in the default web browser
-        webbrowser.open("http://127.0.0.1:5000")
+        if self.open_browser:
+            webbrowser.open("http://127.0.0.1:5000")
 
         # Wait for the server to finish
         server_lock.acquire(blocking=True)

--- a/prompt_doctor/prompt_manager.py
+++ b/prompt_doctor/prompt_manager.py
@@ -1,4 +1,5 @@
 import os
+
 from jinja2 import Template
 
 

--- a/prompt_doctor/templates/debug_tool.html
+++ b/prompt_doctor/templates/debug_tool.html
@@ -13,18 +13,22 @@
             max-width: 800px;
             margin: 0 auto;
         }
+
         h1 {
             color: #333;
         }
+
         label {
             display: block;
             margin-top: 10px;
         }
+
         textarea, input {
             width: 100%;
             padding: 8px;
             margin-top: 5px;
         }
+
         button {
             background-color: #4CAF50;
             border: none;
@@ -37,12 +41,14 @@
             margin-top: 10px;
             cursor: pointer;
         }
+
         #result {
             margin-top: 20px;
             padding: 10px;
             border: 1px solid #ddd;
             background-color: #f9f9f9;
         }
+
         .result-section {
             margin-top: 20px;
             padding: 10px;
@@ -52,55 +58,31 @@
     </style>
 </head>
 <body>
-    <h1>Prompt Doctor Debug Tool</h1>
-    <form id="promptForm">
-        <label for="prompt_id">Prompt ID:</label>
-        <input type="text" id="prompt_id" name="prompt_id" value="{{ prompt_id }}" required>
+<h1>Prompt Doctor Debug Tool</h1>
+<p>Prompt ID: {{ prompt_id }}</p>
+<form id="promptForm" method="post">
+    <label for="prompt_template">Prompt Template:</label>
+    <textarea id="prompt_template" name="prompt_template" rows="10" required>{{ prompt_template }}</textarea>
 
-        <label for="prompt_text">Prompt Text:</label>
-        <textarea id="prompt_text" name="prompt_text" rows="10" required>{{ initial_prompt }}</textarea>
+    <button type="submit" name="action" value="call_llm">Call LLM</button>
+    <button type="submit" name="action" value="save_and_quit">Save Prompt and Quit Debug</button>
+    <button type="submit" name="action" value="discard_and_quit">Discard Changes and Quit Debug</button>
+</form>
 
-        <label for="context">Context (as JSON):</label>
-        <textarea id="context" name="context" rows="5" required>{{ context }}</textarea>
+<div id="context" class="result-section">
+    <h2>Template context:</h2>
+    <pre id="context">{{ context }}</pre>
+</div>
 
-        <button type="submit">Test Prompt</button>
-    </form>
+<div id="result" class="result-section">
+    <h2>Rendered Prompt:</h2>
+    <pre id="rendered_prompt">{{ rendered_prompt }}</pre>
+</div>
 
-    <div id="result" class="result-section">
-        <h2>Rendered Prompt:</h2>
-        <pre id="rendered_prompt"></pre>
-        <p>Version: <span id="version"></span></p>
-    </div>
-
-    <div id="api_result" class="result-section">
-        <h2>API Response:</h2>
-        <pre id="api_response"></pre>
-    </div>
-
-    <script>
-        document.getElementById('promptForm').addEventListener('submit', function(e) {
-            e.preventDefault();
-            
-            // Validate JSON before submitting
-            try {
-                JSON.parse(document.getElementById('context').value);
-            } catch (error) {
-                alert('Invalid JSON in context. Please check and try again.');
-                return;
-            }
-            
-            fetch('/', {
-                method: 'POST',
-                body: new FormData(this)
-            })
-            .then(response => response.json())
-            .then(data => {
-                document.getElementById('rendered_prompt').textContent = data.rendered_prompt;
-                document.getElementById('version').textContent = data.version;
-                document.getElementById('api_response').textContent = data.api_response;
-            })
-            .catch(error => console.error('Error:', error));
-        });
-    </script>
+<div id="llm_response" class="result-section">
+    <h2>API Response:</h2>
+    {# TODO: format LLM response UI #}
+    <pre id="llm_response">{{ llm_response }}</pre>
+</div>
 </body>
 </html>

--- a/prompt_doctor/templates/debug_tool.html
+++ b/prompt_doctor/templates/debug_tool.html
@@ -64,9 +64,10 @@
     <label for="prompt_template">Prompt Template:</label>
     <textarea id="prompt_template" name="prompt_template" rows="10" required>{{ prompt_template }}</textarea>
 
-    <button type="submit" name="action" value="call_llm">Call LLM</button>
-    <button type="submit" name="action" value="save_and_quit">Save Prompt and Quit Debug</button>
-    <button type="submit" name="action" value="discard_and_quit">Discard Changes and Quit Debug</button>
+    <button type="submit" name="action" id="call_llm" value="call_llm">Call LLM</button>
+    <button type="submit" name="action" id="save_and_quit" value="save_and_quit">Save Prompt and Quit Debug</button>
+    <button type="submit" name="action" id="discard_and_quit" value="discard_and_quit">Discard Changes and Quit Debug
+    </button>
 </form>
 
 <div id="context" class="result-section">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "prompt-doctor"
 version = "0.1.0"
 authors = [
-  { name = "Your Name", email = "your.email@example.com" },
+    { name = "Your Name", email = "your.email@example.com" },
 ]
 description = "A tool for debugging and refining LLM prompts in real-time"
 readme = "README.md"
@@ -20,6 +20,10 @@ dependencies = [
     "flask",
     "jinja2",
     "openai>=1.50.0",
+]
+[project.optional-dependencies]
+dev = [
+    "selenium",
 ]
 
 [project.urls]

--- a/tests/test_debug_tool.py
+++ b/tests/test_debug_tool.py
@@ -1,62 +1,237 @@
+import os
+import shutil
+import tempfile
+import threading
+import time
 import unittest
-from unittest.mock import patch, MagicMock
-import json
+import uuid
+from itertools import count
+from unittest.mock import MagicMock
+
+from openai.types.chat import ChatCompletionMessage
+from openai.types.chat.chat_completion import ChatCompletion, Choice
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
 from prompt_doctor.debug_tool import DebugTool
 
 
+def random_id():
+    return str(uuid.uuid4())
+
+
+# disable parallel testing:
 class TestDebugTool(unittest.TestCase):
+
     def setUp(self):
-        self.debug_tool = DebugTool()
+        self.browser = webdriver.Firefox()
+        self.browser.implicitly_wait(5)
+        self.addCleanup(self.browser.quit)
+        self.prompt_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.prompt_dir))
 
-    def test_initialization(self):
-        self.assertIsNotNone(self.debug_tool.app)
-        self.assertIsNotNone(self.debug_tool.prompt_manager)
-
-    @patch("prompt_doctor.debug_tool.threading.Thread")
-    @patch("prompt_doctor.debug_tool.webbrowser.open")
-    @patch("builtins.input")
-    def test_run(self, mock_input, mock_webbrowser, mock_thread):
-        mock_input.return_value = ""
-        self.debug_tool.prompt_manager.list_versions = MagicMock(return_value=[1])
-        self.debug_tool.prompt_manager.get_prompt = MagicMock(
-            return_value=MagicMock(render=lambda x: "Rendered prompt")
-        )
-
-        result = self.debug_tool.run("test_prompt", "Initial prompt", {"key": "value"})
-
-        mock_thread.assert_called_once()
-        mock_webbrowser.assert_called_once_with("http://127.0.0.1:5000")
-        self.assertEqual(result, "Rendered prompt")
-
-    def test_debug_prompt_get(self):
-        with self.debug_tool.app.test_client() as client:
-            response = client.get("/")
-            self.assertEqual(response.status_code, 200)
-
-    @patch("prompt_doctor.debug_tool.call_llm_api")
-    def test_debug_prompt_post(self, mock_call_llm_api):
-        mock_call_llm_api.return_value = "API response"
-        self.debug_tool.prompt_manager.save_prompt = MagicMock(return_value=2)
-        self.debug_tool.prompt_manager.render_prompt = MagicMock(
-            return_value="Rendered prompt"
-        )
-
-        with self.debug_tool.app.test_client() as client:
-            response = client.post(
-                "/",
-                data={
-                    "prompt_id": "test_prompt",
-                    "prompt_text": "Test prompt",
-                    "context": json.dumps({"key": "value"}),
-                },
+        # The Mocked LLM returns "LLM Response #N" for each N-th call
+        self.llm_client_mock = MagicMock()
+        self.llm_client_mock.chat.completions.create.side_effect = (
+            ChatCompletion(
+                choices=[
+                    Choice(
+                        finish_reason="stop",
+                        index=0,
+                        message=ChatCompletionMessage(
+                            content=f"LLM Response #{n}",
+                            role="assistant",
+                        ),
+                    )
+                ],
+                id=f"mocked_result_{n}",
+                created=int(time.time()),
+                model="gpt-4o-mini",
+                object="chat.completion",
             )
+            for n in count(1)
+        )
 
-            self.assertEqual(response.status_code, 200)
-            data = json.loads(response.data)
-            self.assertEqual(data["rendered_prompt"], "Rendered prompt")
-            self.assertEqual(data["version"], 2)
-            self.assertEqual(data["api_response"], "API response")
+        self.debug_tool = DebugTool(
+            self.llm_client_mock, prompts_dir=self.prompt_dir, open_browser=False
+        )
 
+    def _call_create(self, *args, **kwargs):
+        """
+        Call create method of debug_tool in a separate thread to avoid blocking the main thread.
+        The web server will be started (in another thread) when the create method is called.
+        """
+        self.llm_result: ChatCompletion | None = None
 
-if __name__ == "__main__":
-    unittest.main()
+        def create():
+            self.llm_result = self.debug_tool.create(*args, **kwargs)
+
+        create_thread = threading.Thread(target=create, daemon=True)
+        create_thread.start()
+        time.sleep(1)
+
+        self.addCleanup(create_thread.join)
+
+    def test_new_prompt_id(self):
+        """
+        Invoke debug with prompt_id that doesn't exist.
+        Should create one with a default template.
+        """
+        prompt_id = random_id()
+        self._call_create(
+            prompt_id,
+            {"name": "Alice", "age": 25, "location": "New York"},
+            model="gpt-4o-mini",
+        )
+
+        prompt_file = os.path.join(self.prompt_dir, f"{prompt_id}.txt")
+        self.assertTrue(os.path.exists(prompt_file), "Prompt file not created")
+        with open(prompt_file) as f:
+            template_content = f.read()
+
+        self.browser.get("http://localhost:5000")
+        prompt_template = self.browser.find_element(By.ID, "prompt_template")
+        self.assertEqual(
+            prompt_template.text, template_content, "Prompt template not loaded"
+        )
+
+        self.browser.find_element(By.ID, "discard_and_quit").click()
+
+        self.llm_client_mock.chat.completions.create.assert_called_once_with(
+            messages=[
+                {
+                    "content": "Write your prompt template here using Jinja syntax",
+                    "role": "user",
+                }
+            ],
+            model="gpt-4o-mini",
+        )
+
+        self.assertEqual(
+            self.llm_result.choices[0].message.content,
+            "LLM Response #1",
+            "LLM response not returned",
+        )
+
+    def test_discard_and_quit(self):
+        """
+        Invoke debug, edit, call LLM, then "discard and quit" button.
+        Should invoke OpenAI API with the initial prompt.
+        """
+        prompt_id = random_id()
+        prompt_file = os.path.join(self.prompt_dir, f"{prompt_id}.txt")
+        prompt_template_1 = "{{ name }} is {{ age }} years old."
+        with open(prompt_file, "w") as f:
+            f.write(prompt_template_1)
+
+        self._call_create(
+            prompt_id,
+            {"name": "Alice", "age": 25, "location": "New York"},
+            model="gpt-4o-mini",
+        )
+
+        self.browser.get("http://localhost:5000")
+        prompt_template = self.browser.find_element(By.ID, "prompt_template")
+        self.assertEqual(
+            prompt_template.text, prompt_template_1, "Prompt template not loaded"
+        )
+
+        rendered_prompt = self.browser.find_element(By.ID, "rendered_prompt")
+        self.assertEqual(
+            rendered_prompt.text,
+            "Alice is 25 years old.",
+            "Rendered prompt not displayed",
+        )
+
+        # Edit prompt template
+        prompt_template_2 = (
+            "{{ name }} is {{ age }} years old and lives in {{ location }}."
+        )
+        prompt_template.clear()
+        prompt_template.send_keys(prompt_template_2)
+        self.browser.find_element(By.ID, "call_llm").click()
+
+        # Assert template and rendered shows new prompt:
+        prompt_template = self.browser.find_element(By.ID, "prompt_template")
+        self.assertEqual(
+            prompt_template.text, prompt_template_2, "Prompt template not loaded"
+        )
+
+        rendered_prompt = self.browser.find_element(By.ID, "rendered_prompt")
+        self.assertEqual(
+            rendered_prompt.text,
+            "Alice is 25 years old and lives in New York.",
+            "Rendered prompt not displayed",
+        )
+
+        self.browser.find_element(By.ID, "discard_and_quit").click()
+
+        with open(prompt_file) as f:
+            self.assertEqual(f.read(), prompt_template_1, "Prompt template modified")
+
+        self.assertEqual(
+            self.llm_result.choices[0].message.content,
+            "LLM Response #2",
+            "LLM response not returned",
+        )
+
+    def test_edit_prompt_and_save(self):
+        """
+        Invoke debug, edit, click "call LLM" and then "save and quit" button.
+        Should invoke OpenAI API with the initial prompt, then with the edited prompt.
+        """
+        prompt_id = random_id()
+        prompt_file = os.path.join(self.prompt_dir, f"{prompt_id}.txt")
+        prompt_template_1 = "{{ name }} is {{ age }} years old."
+        with open(prompt_file, "w") as f:
+            f.write(prompt_template_1)
+
+        self._call_create(
+            prompt_id,
+            {"name": "Alice", "age": 25, "location": "New York"},
+            model="gpt-4o-mini",
+        )
+
+        self.browser.get("http://localhost:5000")
+        prompt_template = self.browser.find_element(By.ID, "prompt_template")
+        self.assertEqual(
+            prompt_template.text, prompt_template_1, "Prompt template not loaded"
+        )
+
+        rendered_prompt = self.browser.find_element(By.ID, "rendered_prompt")
+        self.assertEqual(
+            rendered_prompt.text,
+            "Alice is 25 years old.",
+            "Rendered prompt not displayed",
+        )
+
+        # Edit prompt template
+        prompt_template_2 = (
+            "{{ name }} is {{ age }} years old and lives in {{ location }}."
+        )
+        prompt_template.clear()
+        prompt_template.send_keys(prompt_template_2)
+        self.browser.find_element(By.ID, "call_llm").click()
+
+        # Assert template and rendered shows new prompt:
+        prompt_template = self.browser.find_element(By.ID, "prompt_template")
+        self.assertEqual(
+            prompt_template.text, prompt_template_2, "Prompt template not loaded"
+        )
+
+        rendered_prompt = self.browser.find_element(By.ID, "rendered_prompt")
+        self.assertEqual(
+            rendered_prompt.text,
+            "Alice is 25 years old and lives in New York.",
+            "Rendered prompt not displayed",
+        )
+        self.browser.find_element(By.ID, "save_and_quit").click()
+
+        with open(prompt_file) as f:
+            self.assertEqual(f.read(), prompt_template_2, "Prompt template not saved")
+
+        self.assertEqual(
+            self.llm_result.choices[0].message.content,
+            "LLM Response #2",
+            "LLM response not returned",
+        )


### PR DESCRIPTION
I hope you don't mind that I changed a lot of your code, but I refactor so that from the caller's perspective, chat.create is just like calling OpenAI client, except that when wrapped in the DebugTool, it starts the server allowing the user to play with the prompt template until he's satisfied and continues/releases with the application.

Couple of decisions:

 - Sorry, I removed the JS in the page because: OpenAI call takes a while and without a "loading" UI it seems frozen. Multiple submissions is possible and breaks, and for some reason the button's values are not being sent via JS call.
 - Let's talk more about versioning. I think Git can take care of most of it, so we don't need to reinvent the wheel. Probably something simple as "save or discard" and maybe "revert" are good enough
 - Regarding the system and multiple messages; I think we can extend the template to support it (with marks or other syntax)
 
 I'll fix the tests after the review of this PR